### PR TITLE
Fixed stringintconv issue

### DIFF
--- a/query/sexp/parser.go
+++ b/query/sexp/parser.go
@@ -190,7 +190,7 @@ func getIdentString(tree *peg.ExpressionTree) string {
 		}
 	} else {
 		if tree.Value != '"' {
-			out += string(tree.Value)
+			out += string(byte(tree.Value))
 		}
 	}
 	return out


### PR DESCRIPTION
This made the tests fail in Go 1.16 and above